### PR TITLE
Add support for Ruby 2.1

### DIFF
--- a/ext/deep_clone/deep_clone.c
+++ b/ext/deep_clone/deep_clone.c
@@ -105,7 +105,8 @@ static VALUE clone_object(VALUE object, VALUE tracker)
         OBJ_UNFREEZE(new_obj);
 
         rb_hash_aset(tracker,id,new_obj);
-        st_table *tbl = ROBJECT_IV_INDEX_TBL(object);
+        st_table *tbl = DC_ROBJECT_IV_INDEX_TBL(object);
+
         if(tbl) {
           struct dump_call_arg arg = {new_obj,tracker, object};
           TABLE_FOREACH(tbl, clone_variable, (st_data_t)&arg);

--- a/ext/deep_clone/deep_clone.h
+++ b/ext/deep_clone/deep_clone.h
@@ -3,6 +3,7 @@
 
 #include "ruby.h"
 #include "ruby/st.h"
+#include "ruby/version.h"
 
 struct dump_call_arg {
   VALUE obj;
@@ -17,7 +18,7 @@ struct dump_call_arg {
 #ifdef SA_EMPTY
 
 // Gotta do this because of 1.9.3's falcon patch
- struct rb_classext_struct {
+struct rb_classext_struct {
     sa_table m_tbl;
     sa_table iv_tbl;
     sa_table const_tbl;
@@ -25,15 +26,34 @@ struct dump_call_arg {
 };
 
 #define TABLE_FOREACH sa_foreach
-#define RCLASS_EXT(c) (RCLASS(c)->ptr)
-#define RCLASS_IV_INDEX_TBL(c) (&RCLASS_EXT(c)->iv_index_tbl)
+#define DC_RCLASS_EXT(c) (RCLASS(c)->ptr)
+#define DC_RCLASS_IV_INDEX_TBL(c) (&DC_RCLASS_EXT(c)->iv_index_tbl)
 
 #else
 // Make it work with vanilla ruby (including 2.0)
-#define RCLASS_IV_INDEX_TBL(c) (RCLASS(c)->iv_index_tbl)
 #define TABLE_FOREACH st_foreach
 
+#if RUBY_API_VERSION_CODE >= 20100
+
+// In Ruby 2.1, iv_index_tbl was moved into internal.h and cannot be accessed
+// directly. We work around this by defining our own RCLASS helpers (since the
+// rb_classext_struct returned by RCLASS_EXT is also effectively private).
+typedef struct dc_iv_tbl_classext_struct {
+    struct st_table *iv_index_tbl;
+} dc_iv_tbl_classext_t;
+
+#define DC_RCLASS_EXT(c)          ((dc_iv_tbl_classext_t *)RCLASS(c)->ptr)
+#define DC_RCLASS_IV_INDEX_TBL(c) (DC_RCLASS_EXT(c)->iv_index_tbl)
+
+#else
+#define DC_RCLASS_IV_INDEX_TBL(c) (RCLASS(c)->iv_index_tbl)
 #endif
+#endif
+
+#define DC_ROBJECT_IV_INDEX_TBL(o) \
+    ((RBASIC(o)->flags & ROBJECT_EMBED) ? \
+     DC_RCLASS_IV_INDEX_TBL(rb_obj_class(o)) : \
+     ROBJECT(o)->as.heap.iv_index_tbl)
 
 VALUE DeepClone = Qnil;
 


### PR DESCRIPTION
Ruby 2.1 moves the `iv_index_tbl` attribute into `rb_classext_struct`, defined in internal.h (see: ruby/ruby@34096909). This meant that it was no longer possible to access it directly using `RCLASS_EXT()`. I added support for Ruby 2.1 by casting the struct returned by `RCLASS()` into a new struct, from which we can access `iv_index_tbl` (much like Ruby itself does [in classext.h](https://github.com/ruby/ruby/blob/v1_9_3_484/include/ruby/backward/classext.h)).

Anyway... I compiled and tested the library with Ruby 1.9.3-p484, 2.0.0-p353, and 2.1.0-p0. I haven't been able to test 1.9.3 with the falcon patch, but I don't see any reason for this patch to break it since the only relevant change affecting it is the renamed macros (the added "DC_" prefix).

Thanks!
