### PR TITLE
Fix the "`clone': allocator undefined for Symbol" Type Error

### DIFF
--- a/ext/deep_clone/deep_clone.c
+++ b/ext/deep_clone/deep_clone.c
@@ -58,7 +58,7 @@ static int hash_each(VALUE key, VALUE value, struct dump_call_arg *arg)
 
 static VALUE clone_object(VALUE object, VALUE tracker)
 {
-  if(rb_special_const_p(object))
+  if(rb_special_const_p(object) || RB_SYMBOL_P(object))
   {
     return object;
   }

--- a/spec/deep_clone/builtin_clone_spec.rb
+++ b/spec/deep_clone/builtin_clone_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'json'
 
 describe DeepClone do
   describe '.clone' do
@@ -48,6 +49,13 @@ describe DeepClone do
       s2 = DeepClone.clone s1
 
       expect(s1.object_id).to_not eq(s2.object_id)
+    end
+
+    it 'should clone dynamic symbols' do
+      hash = JSON.parse('{"abc": 1, "bcd": 1, "cef": 1 }', symbolize_names: true)
+      hash2 = DeepClone.clone hash
+
+      expect(hash.object_id).to_not eq(hash2.object_id)
     end
   end
 end


### PR DESCRIPTION
Hi, I've been able to reproduce the issue #8 in the specs and I've found a fix.

To reproduce the issue I had to parse a JSON string into a hash with the `symbolize_names` option set to `true`.

I'm still not sure why those are not normal `Symbol`, but rather "Dynamic Symbols" https://github.com/ruby/ruby/blob/trunk/include/ruby/ruby.h#L377

Anyway, the fix seems to work fine, but I don't know if that's the best way to code it. 

I know the gem is no longer maintained but we still depend on it for our app and we can't change our JSON parser because of this bug. I'll gladly take ownership of it.

Cheers   